### PR TITLE
Initialize SvelteKit skill map project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # my-skillmap
+
+SvelteKit-based interactive skill tree that visualizes categories and skills using ECharts bubble charts and Tailwind CSS.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/data/skills.json
+++ b/data/skills.json
@@ -1,0 +1,44 @@
+{
+  "categories": [
+    {
+      "id": "soft",
+      "name": "軟實力",
+      "color": "#60a5fa",
+      "nodes": [
+        {
+          "id": "communication",
+          "name": "溝通表達",
+          "level": 4,
+          "summary": "跨部門協作、需求澄清、衝突管理",
+          "examples": [
+            {
+              "title": "跨部門成本優化提案",
+              "link": "#"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "hard",
+      "name": "硬實力",
+      "color": "#34d399",
+      "nodes": [
+        {
+          "id": "backend",
+          "name": "Backend Development",
+          "level": 5,
+          "summary": "Java/Spring Boot、Node.js、分散式系統",
+          "subskills": [
+            { "name": "Java", "level": 5 },
+            { "name": "Spring Boot", "level": 5 },
+            { "name": "Node.js", "level": 3 }
+          ],
+          "examples": [
+            { "title": "DSP/RTB 投放平台", "link": "#" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "my-skillmap",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "npm run check"
+  },
+  "dependencies": {
+    "echarts": "^5.4.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^4.0.0",
+    "svelte-check": "^3.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="@sveltejs/kit" />
+
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare global {
+  namespace App {
+    // interface Locals {}
+    // interface PageData {}
+    // interface Error {}
+    // interface Platform {}
+  }
+}
+
+export {};

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  export let items: { href: string; label: string }[] = [];
+</script>
+
+<nav class="text-sm text-gray-500 mb-4">
+  {#each items as item, i}
+    <a href={item.href} class="hover:underline">{item.label}</a>
+    {#if i < items.length - 1}
+      <span class="mx-1">/</span>
+    {/if}
+  {/each}
+</nav>

--- a/src/lib/components/BubbleChart.svelte
+++ b/src/lib/components/BubbleChart.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  export let nodes: { id: string; name: string; value?: number; color?: string }[] = [];
+  export let onClick: (id: string) => void;
+  let el: HTMLDivElement;
+
+  onMount(() => {
+    const chart = echarts.init(el);
+    chart.setOption({
+      tooltip: { trigger: 'item' },
+      series: [{
+        type: 'graph',
+        layout: 'force',
+        roam: true,
+        label: { show: true },
+        force: { repulsion: 200, edgeLength: 50 },
+        data: nodes.map((n) => ({
+          id: n.id, name: n.name, value: n.value ?? 3,
+          symbolSize: 40 + (n.value ?? 3) * 8,
+          itemStyle: { color: n.color }
+        }))
+      }]
+    });
+    chart.on('click', (p: any) => onClick?.(p.data.id));
+    const onResize = () => chart.resize();
+    window.addEventListener('resize', onResize);
+    return () => { window.removeEventListener('resize', onResize); chart.dispose(); };
+  });
+</script>
+
+<div bind:this={el} class="h-[60vh] w-full" />

--- a/src/lib/components/SkillCard.svelte
+++ b/src/lib/components/SkillCard.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let id: string;
+  export let name: string;
+  export let level: number = 3;
+  export let summary?: string;
+</script>
+
+<a href={`/skill/${id}`} class="p-4 rounded-2xl border hover:shadow transition">
+  <div class="flex items-center justify-between mb-2">
+    <h3 class="font-semibold">{name}</h3>
+    <span class="text-xs bg-gray-100 rounded px-2 py-0.5">Lv {level}</span>
+  </div>
+  {#if summary}
+    <p class="text-sm text-gray-600 line-clamp-2">{summary}</p>
+  {/if}
+</a>

--- a/src/lib/stores/skills.ts
+++ b/src/lib/stores/skills.ts
@@ -1,0 +1,22 @@
+import { readable } from 'svelte/store';
+import data from '../../data/skills.json';
+
+export type Skill = {
+  id: string; name: string; level?: number; summary?: string;
+  subskills?: { name: string; level?: number }[];
+  examples?: { title: string; link: string }[];
+};
+export type Category = { id: string; name: string; color?: string; nodes: Skill[] };
+
+export const skillsData = readable<{ categories: Category[] }>(data);
+
+export function findCategory(id: string, d = data) {
+  return d.categories.find((c: Category) => c.id === id);
+}
+export function findSkill(skillId: string, d = data) {
+  for (const c of d.categories) {
+    const m = c.nodes.find((n) => n.id === skillId);
+    if (m) return { category: c, skill: m };
+  }
+  return null;
+}

--- a/src/lib/utils/echarts.ts
+++ b/src/lib/utils/echarts.ts
@@ -1,0 +1,2 @@
+import * as echarts from 'echarts';
+export default echarts;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import '../app.css';
+</script>
+
+<slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { skillsData } from '$lib/stores/skills';
+  import { get } from 'svelte/store';
+  import BubbleChart from '$lib/components/BubbleChart.svelte';
+  import { goto } from '$app/navigation';
+
+  const data = get(skillsData);
+  const nodes = data.categories.map(c => ({ id: c.id, name: c.name, value: c.nodes.length, color: c.color }));
+  function handleClick(id: string) { goto(`/category/${id}`); }
+</script>
+
+<section class="container mx-auto p-6">
+  <h1 class="text-3xl font-bold mb-4">技能總覽</h1>
+  <p class="text-sm text-gray-500 mb-6">點擊類別泡泡進入下一層</p>
+  <BubbleChart {nodes} onClick={handleClick} />
+</section>

--- a/src/routes/category/[id]/+page.svelte
+++ b/src/routes/category/[id]/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { findCategory } from '$lib/stores/skills';
+  import SkillCard from '$lib/components/SkillCard.svelte';
+  import type { PageLoad } from './$types';
+  export const load: PageLoad = ({ params }) => ({ id: params.id });
+  export let data: { id: string };
+  const category = findCategory(data.id);
+</script>
+
+<section class="container mx-auto p-6">
+  <a href="/" class="text-sm text-gray-500">← 返回總覽</a>
+  <h2 class="text-2xl font-bold my-4">{category?.name}</h2>
+  <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    {#each category?.nodes ?? [] as s}
+      <SkillCard id={s.id} name={s.name} level={s.level ?? 3} summary={s.summary} />
+    {/each}
+  </div>
+</section>

--- a/src/routes/skill/[id]/+page.svelte
+++ b/src/routes/skill/[id]/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { findSkill } from '$lib/stores/skills';
+  import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+  import type { PageLoad } from './$types';
+  export const load: PageLoad = ({ params }) => ({ id: params.id });
+  export let data: { id: string };
+  const found = findSkill(data.id);
+</script>
+
+{#if found}
+  <section class="container mx-auto p-6 space-y-4">
+    <Breadcrumbs items={[
+      { href: '/', label: 'Home' },
+      { href: `/category/${found.category.id}`, label: found.category.name },
+      { href: `/skill/${found.skill.id}`, label: found.skill.name }
+    ]} />
+    <h1 class="text-3xl font-bold">{found.skill.name}</h1>
+    <p class="text-gray-700">{found.skill.summary}</p>
+
+    {#if found.skill.subskills?.length}
+      <div class="flex flex-wrap gap-2">
+        {#each found.skill.subskills as t}
+          <span class="text-xs bg-emerald-50 text-emerald-700 px-2 py-1 rounded-full">{t.name} · Lv {t.level ?? 3}</span>
+        {/each}
+      </div>
+    {/if}
+
+    {#if found.skill.examples?.length}
+      <div>
+        <h3 class="font-semibold mb-2">案例 / 連結</h3>
+        <ul class="list-disc ml-5 space-y-1">
+          {#each found.skill.examples as ex}
+            <li><a class="text-blue-600 hover:underline" href={ex.link} target="_blank" rel="noreferrer">{ex.title}</a></li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  </section>
+{:else}
+  <p class="p-6">查無此技能</p>
+{/if}

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#16a34a" />
+  <text x="50" y="55" font-size="50" text-anchor="middle" fill="#fff">S</text>
+</svg>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,11 @@
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/kit/vite';
+
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ['./src/**/*.{html,js,svelte,ts}'],
+  theme: { extend: {} },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "types": ["svelte"]
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold SvelteKit app with Tailwind and ECharts bubble chart
- add sample skills data and store helpers
- implement overview, category, and skill detail pages

## Testing
- `npm test` *(fails: svelte-check not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896cea3980083319afcb218cc086e6a